### PR TITLE
Add support for CryptoPP versions before 6.0

### DIFF
--- a/deterministic_rng.h
+++ b/deterministic_rng.h
@@ -1,6 +1,17 @@
 #include <sodium/crypto_stream_chacha20.h>
 #include <cryptopp/cryptlib.h>
 
+#if (CRYPTOPP_VERSION <= 600)
+    // cryptopp made the unfathomable decision to add
+    // their byte type to the standard namespace, which
+    // is only fixed later on (from version 6.0)
+    namespace CryptoPP {
+        // use the byte that was erroneously defined
+        // in the global namespace
+        using byte = ::byte;
+    }
+#endif
+
 
 /**
  *  Deterministic RNG using the ChaCha20 stream cipher.


### PR DESCRIPTION
The key generation also needs this CryptoPP workaround.