### PR TITLE
Use pgp::variant and friends, not mpark::variant

### DIFF
--- a/generate_key.h
+++ b/generate_key.h
@@ -132,14 +132,14 @@ std::vector<pgp::packet> generate_key(const master_key &master, std::string user
 
     // add the primary key packet
     packets.push_back(params_t::secret_key_packet(parameters::key_type::main, creation, keys.main_key_public, keys.main_key_secret));
-    auto &main_key = mpark::get<pgp::secret_key>(packets[0].body());
+    auto &main_key = pgp::get<pgp::secret_key>(packets[0].body());
 
     // add the user id packet
     packets.emplace_back(
-       mpark::in_place_type_t<pgp::user_id>{},   // we are building a user id
+       pgp::in_place_type_t<pgp::user_id>{},     // we are building a user id
        std::move(user)                           // for this user
     );
-    auto &user_id = mpark::get<pgp::user_id>(packets[1].body());
+    auto &user_id = pgp::get<pgp::user_id>(packets[1].body());
 
     // add self-signature for the main key
     packets.push_back(params_t::user_id_signature_packet(user_id, main_key, signature, expiration));
@@ -154,7 +154,7 @@ std::vector<pgp::packet> generate_key(const master_key &master, std::string user
         packets.push_back(params_t::secret_key_packet(type, creation, public_key, secret_key));
 
         // retrieve the created key; we need it to construct the signature packet
-        auto &created_key = mpark::get<pgp::secret_subkey>(packets.back().body());
+        auto &created_key = pgp::get<pgp::secret_subkey>(packets.back().body());
 
         // add a self-signature for the subkey
         packets.push_back(params_t::subkey_signature_packet(type, created_key, main_key, signature, expiration));

--- a/packet_utils.cpp
+++ b/packet_utils.cpp
@@ -15,7 +15,7 @@ namespace packet_utils {
     pgp::packet user_id_signature(const pgp::user_id &user_id, const pgp::secret_key &main_key, uint32_t signature_creation, uint32_t signature_expiration)
     {
         return pgp::packet{
-            mpark::in_place_type_t<pgp::signature>{},                                        // we are making a signature
+            pgp::in_place_type_t<pgp::signature>{},                                          // we are making a signature
             main_key,                                                                        // we sign with the main key
             user_id,                                                                         // for this user
             pgp::signature_subpacket_set{{                                                   // hashed subpackets
@@ -59,7 +59,7 @@ namespace packet_utils {
         if (key_flags.is_set(pgp::key_flag::signing)) {
             // add a cross-signature (https://gnupg.org/faq/subkey-cross-certify.html)
             unhashed_subpackets.emplace_back(
-                mpark::in_place_type_t<pgp::signature_subpacket::embedded_signature>{},           // this is an embedded signature packet
+                pgp::in_place_type_t<pgp::signature_subpacket::embedded_signature>{},             // this is an embedded signature packet
                 pgp::signature{
                     subkey,                                                                       // with the subkey
                     main_key,                                                                     // we sign the main key
@@ -75,7 +75,7 @@ namespace packet_utils {
         }
 
         return pgp::packet{
-            mpark::in_place_type_t<pgp::signature>{},                                        // subkey signature
+            pgp::in_place_type_t<pgp::signature>{},                                          // subkey signature
             main_key,                                                                        // we sign with the main key
             subkey,                                                                          // indicating we own this subkey
             pgp::signature_subpacket_set{{                                                   // hashed subpackets

--- a/parameters_ecdsa.cpp
+++ b/parameters_ecdsa.cpp
@@ -56,10 +56,10 @@ pgp::packet parameters::ecdsa::secret_key_packet(key_type type, uint32_t creatio
     switch (type) {
         case key_type::main:
             return pgp::packet{
-                mpark::in_place_type_t<pgp::secret_key>{},                  // we are building a secret key
+                pgp::in_place_type_t<pgp::secret_key>{},                    // we are building a secret key
                 creation,                                                   // created at
                 pgp::key_algorithm::ecdsa,                                  // using the ecdsa key algorithm
-                mpark::in_place_type_t<pgp::secret_key::ecdsa_key_t>{},     // key type
+                pgp::in_place_type_t<pgp::secret_key::ecdsa_key_t>{},       // key type
                 std::forward_as_tuple(                                      // public arguments
                     pgp::curve_oid::ecdsa(),                                // curve to use
                     pgp::multiprecision_integer{ public_key }               // copy in the public key point
@@ -72,10 +72,10 @@ pgp::packet parameters::ecdsa::secret_key_packet(key_type type, uint32_t creatio
         case key_type::signing:
         case key_type::authentication:
             return pgp::packet{
-                mpark::in_place_type_t<pgp::secret_subkey>{},               // we are building a secret subkey
+                pgp::in_place_type_t<pgp::secret_subkey>{},                 // we are building a secret subkey
                 creation,                                                   // created at
                 pgp::key_algorithm::ecdsa,                                  // using the ecdsa key algorithm
-                mpark::in_place_type_t<pgp::secret_key::ecdsa_key_t>{},     // key type
+                pgp::in_place_type_t<pgp::secret_key::ecdsa_key_t>{},       // key type
                 std::forward_as_tuple(                                      // public arguments
                     pgp::curve_oid::ecdsa(),                                // curve to use
                     pgp::multiprecision_integer{ public_key }               // copy in the public key point
@@ -87,10 +87,10 @@ pgp::packet parameters::ecdsa::secret_key_packet(key_type type, uint32_t creatio
 
         case key_type::encryption:
             return pgp::packet{
-                mpark::in_place_type_t<pgp::secret_subkey>{},               // we are building a secret subkey
+                pgp::in_place_type_t<pgp::secret_subkey>{},                 // we are building a secret subkey
                 creation,                                                   // created at
                 pgp::key_algorithm::ecdh,                                   // using the ecdh key algorithm
-                mpark::in_place_type_t<pgp::secret_key::ecdh_key_t>{},      // key type
+                pgp::in_place_type_t<pgp::secret_key::ecdh_key_t>{},        // key type
                 std::forward_as_tuple(                                      // public arguments
                     pgp::curve_oid::ecdsa(),                                // curve to use
                     pgp::multiprecision_integer{ public_key },              // copy in the public key point

--- a/parameters_eddsa.cpp
+++ b/parameters_eddsa.cpp
@@ -76,10 +76,10 @@ pgp::packet parameters::eddsa::secret_key_packet(key_type type, uint32_t creatio
     switch (type) {
         case key_type::main:
             return pgp::packet{
-                mpark::in_place_type_t<pgp::secret_key>{},                  // we are building a secret key
+                pgp::in_place_type_t<pgp::secret_key>{},                    // we are building a secret key
                 creation,                                                   // created at
                 pgp::key_algorithm::eddsa,                                  // using the eddsa key algorithm
-                mpark::in_place_type_t<pgp::secret_key::eddsa_key_t>{},     // key type
+                pgp::in_place_type_t<pgp::secret_key::eddsa_key_t>{},       // key type
                 std::forward_as_tuple(                                      // public arguments
                     pgp::curve_oid::ed25519(),                              // curve to use
                     pgp::multiprecision_integer{ public_key }               // copy in the public key point
@@ -92,10 +92,10 @@ pgp::packet parameters::eddsa::secret_key_packet(key_type type, uint32_t creatio
         case key_type::signing:
         case key_type::authentication:
             return pgp::packet{
-                mpark::in_place_type_t<pgp::secret_subkey>{},               // we are building a secret subkey
+                pgp::in_place_type_t<pgp::secret_subkey>{},                 // we are building a secret subkey
                 creation,                                                   // created at
                 pgp::key_algorithm::eddsa,                                  // using the eddsa key algorithm
-                mpark::in_place_type_t<pgp::secret_key::eddsa_key_t>{},     // key type
+                pgp::in_place_type_t<pgp::secret_key::eddsa_key_t>{},       // key type
                 std::forward_as_tuple(                                      // public arguments
                     pgp::curve_oid::ed25519(),                              // curve to use
                     pgp::multiprecision_integer{ public_key }               // copy in the public key point
@@ -107,10 +107,10 @@ pgp::packet parameters::eddsa::secret_key_packet(key_type type, uint32_t creatio
 
         case key_type::encryption:
             return pgp::packet{
-                mpark::in_place_type_t<pgp::secret_subkey>{},                // we are building a secret subkey
+                pgp::in_place_type_t<pgp::secret_subkey>{},                  // we are building a secret subkey
                 creation,                                                    // created at
                 pgp::key_algorithm::ecdh,                                    // using the ecdh key algorithm
-                mpark::in_place_type_t<pgp::secret_key::ecdh_key_t>{},       // key type
+                pgp::in_place_type_t<pgp::secret_key::ecdh_key_t>{},         // key type
                 std::forward_as_tuple(                                       // public arguments
                     pgp::curve_oid::curve_25519(),                           // curve to use
                     pgp::multiprecision_integer{ public_key },               // copy in the public key point

--- a/parameters_rsa.cpp
+++ b/parameters_rsa.cpp
@@ -57,10 +57,10 @@ pgp::packet parameters::rsa<modulus_size>::secret_key_packet(key_type type, uint
     switch (type) {
         case key_type::main:
             return pgp::packet{
-                mpark::in_place_type_t<pgp::secret_key>{},                  // we are building a secret key
+                pgp::in_place_type_t<pgp::secret_key>{},                    // we are building a secret key
                 creation,                                                   // created at
                 pgp::key_algorithm::rsa_encrypt_or_sign,                    // using the rsa key algorithm
-                mpark::in_place_type_t<pgp::secret_key::rsa_key_t>{},       // key type
+                pgp::in_place_type_t<pgp::secret_key::rsa_key_t>{},         // key type
                 std::forward_as_tuple(                                      // public arguments
                     public_key.n, public_key.e                              // copy in the public key parameters
                 ),
@@ -72,10 +72,10 @@ pgp::packet parameters::rsa<modulus_size>::secret_key_packet(key_type type, uint
         case key_type::signing:
         case key_type::authentication:
             return pgp::packet{
-                mpark::in_place_type_t<pgp::secret_subkey>{},               // we are building a secret subkey
+                pgp::in_place_type_t<pgp::secret_subkey>{},                 // we are building a secret subkey
                 creation,                                                   // created at
                 pgp::key_algorithm::rsa_encrypt_or_sign,                    // using the rsa key algorithm
-                mpark::in_place_type_t<pgp::secret_key::rsa_key_t>{},       // key type
+                pgp::in_place_type_t<pgp::secret_key::rsa_key_t>{},         // key type
                 std::forward_as_tuple(                                      // public arguments
                     public_key.n, public_key.e                              // copy in the public key parameters
                 ),
@@ -86,10 +86,10 @@ pgp::packet parameters::rsa<modulus_size>::secret_key_packet(key_type type, uint
 
         case key_type::encryption:
             return pgp::packet{
-                mpark::in_place_type_t<pgp::secret_subkey>{},               // we are building a secret subkey
+                pgp::in_place_type_t<pgp::secret_subkey>{},                 // we are building a secret subkey
                 creation,                                                   // created at
                 pgp::key_algorithm::rsa_encrypt_or_sign,                    // using the rsa key algorithm
-                mpark::in_place_type_t<pgp::secret_key::rsa_key_t>{},       // key type
+                pgp::in_place_type_t<pgp::secret_key::rsa_key_t>{},         // key type
                 std::forward_as_tuple(                                      // public arguments
                     public_key.n, public_key.e                              // copy in the public key parameters
                 ),


### PR DESCRIPTION
**This PR is dependent on https://github.com/summitto/pgp-packet-library/pull/21, and should be merged after that PR.**

This modifies the key generation application to use the new pgp::variant and associated functions.