### PR TITLE
Specify languages used in the project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 3.8.0)
-project(pgp-test)
+
+project(pgp-test
+    VERSION     0.1.1
+    LANGUAGES   CXX
+)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 


### PR DESCRIPTION
* By default, CMake assumes C and CXX
* CMake thus performs unnecessary checks
* It's good to be explicit about these things