### PR TITLE
Static analysis

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,3 +46,13 @@ if (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.2)
 endif()
 
 add_subdirectory(tests)
+
+# Custom target for clang-tidy
+find_program(clang_tidy_path NAMES clang-tidy)
+if (clang_tidy_path)
+    add_custom_target(tidy
+        COMMAND ${clang_tidy_path} -p="${CMAKE_CURRENT_BINARY_DIR}" ${sources-list}
+        COMMENT "Running clang-tidy"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+endif()

--- a/clang_analyze.sh
+++ b/clang_analyze.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -ge 1 && ($1 = "-h" || $1 = "--help") ]]; then
+    echo >&2 "Usage: $0 [custom CMake arguments...]"
+    echo >&2 "Will compile the application using the Clang static analyzer."
+    echo >&2 "Any arguments to the script will be passed verbatim to CMake in addition to"
+    echo >&2 "the arguments necessary for this script."
+    exit 0
+fi
+
+sourcedir="$(dirname "$0")"
+builddir="$(mktemp -d)"
+
+trap "rm -rf '$builddir'" EXIT
+
+nthreads="$(nproc || echo -n "")"
+if [[ -z $nthreads ]]; then
+    nthreads=4
+    echo >&2 "Warning: Could not determine number of CPU cores, using $nthreads"
+fi
+
+CC=clang CXX=clang++ scan-build --use-cc=clang --use-c++=clang++ cmake -S "$sourcedir" -B "$builddir" -DCMAKE_BUILD_TYPE=Debug "$@"
+scan-build --use-cc=clang --use-c++=clang++ make -j$(nproc) -C"$builddir"


### PR DESCRIPTION
This adds some infrastructure to perform static analysis on the key generation application.

clang-tidy reports a warning about a virtual call in a constructor within Crypto++. Since that seems out of scope here, the build is currently clean. :)