### PR TITLE
Fix PVS-produced warnings

### DIFF
--- a/generate_derived_key.cpp
+++ b/generate_derived_key.cpp
@@ -137,7 +137,7 @@ namespace {
         void ensure_prompt(boost::string_view prompt) noexcept
         {
             // if we have a value already, nothing to do
-            if (std::optional<T>::has_value()) {
+            if (this->has_value()) {
                 return;
             }
 

--- a/hexadecimal.h
+++ b/hexadecimal.h
@@ -24,7 +24,7 @@ std::array<uint8_t, width> convert_string_to_numbers(const std::string &input)
     // iterate over the entire string
     for (size_t i = 0; i < width; ++i) {
         // the value to parse into
-        int value;
+        unsigned int value;
 
         // read the value from the string
         std::sscanf(input.data() + 2*i, "%02x", &value);

--- a/parameters_rsa.cpp
+++ b/parameters_rsa.cpp
@@ -71,19 +71,6 @@ pgp::packet parameters::rsa<modulus_size>::secret_key_packet(key_type type, uint
 
         case key_type::signing:
         case key_type::authentication:
-            return pgp::packet{
-                pgp::in_place_type_t<pgp::secret_subkey>{},                 // we are building a secret subkey
-                creation,                                                   // created at
-                pgp::key_algorithm::rsa_encrypt_or_sign,                    // using the rsa key algorithm
-                pgp::in_place_type_t<pgp::secret_key::rsa_key_t>{},         // key type
-                std::forward_as_tuple(                                      // public arguments
-                    public_key.n, public_key.e                              // copy in the public key parameters
-                ),
-                std::forward_as_tuple(                                      // secret arguments
-                    secret_key.d, secret_key.p, secret_key.q, secret_key.u  // copy in the secret key parameters
-                )
-            };
-
         case key_type::encryption:
             return pgp::packet{
                 pgp::in_place_type_t<pgp::secret_subkey>{},                 // we are building a secret subkey


### PR DESCRIPTION
This solves some potential bugs in the code. One warning is left for stylistic reasons and should have an exception rule in the future.