### PR TITLE
Remove duplicate include

### DIFF
--- a/hexadecimal.h
+++ b/hexadecimal.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <array>
-#include <charconv>
 #include <cstdint>
 #include <string>
 #include <system_error>


### PR DESCRIPTION
When compiling with an old STL version, charconv should not be included.
A duplicate include of charconv had to be removed to make this work.