### PR TITLE
Build and test on macos-latest / ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,7 @@ on:
 
 jobs:
   appleclang:
-<<<<<<< HEAD
     name: appleclang-11.0.3
-=======
-    name: AppleClang-11.0.3
->>>>>>> 448f320... Build and test on latest ubuntu
     runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,4 +1,4 @@
-name: "build and test"
+name: "pgp-key-generation CI"
 
 on:
   push:
@@ -8,24 +8,56 @@ on:
 
 jobs:
   appleclang:
+<<<<<<< HEAD
     name: appleclang-11.0.3
+=======
+    name: AppleClang-11.0.3
+>>>>>>> 448f320... Build and test on latest ubuntu
     runs-on: macos-latest
     env:
       DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
 
     steps:
-    - uses: actions/checkout@v2
-    - name: dependencies
-      run: brew install boost cryptopp
-    - name: pgp-packet-library
-      run: |
-        git clone https://github.com/summitto/pgp-packet-library.git
-        git -C pgp-packet-library submodule update --init --recursive
-        cmake -B pgp-packet-library/build -S pgp-packet-library -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=ci-install
-        cmake --build pgp-packet-library/build --target install
-    - name: cmake
-      run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=ci-install
-    - name: build
-      run: cmake --build build
-    - name: test
-      run: make -C build test
+      - uses: actions/checkout@v2
+      - name: dependencies
+        run: brew install boost cryptopp
+      - name: pgp-packet-library
+        run: |
+          git clone https://github.com/summitto/pgp-packet-library.git
+          git -C pgp-packet-library submodule update --init --recursive
+          cmake -B pgp-packet-library/build -S pgp-packet-library -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=ci-install
+          cmake --build pgp-packet-library/build --target install
+      - name: cmake
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=ci-install
+      - name: build
+        run: cmake --build build
+      - name: test
+        run: make -C build test
+
+  clang:
+    name: clang-9
+    runs-on: ubuntu-latest
+    
+    steps:
+      - uses: actions/checkout@v2
+      - name: dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libsodium-dev libcrypto++-dev
+          pip3 install dataclasses
+          cd ${BOOST_ROOT_1_72_0}
+          sudo ./bootstrap.sh
+          sudo ./b2 install --with-program_options -j2
+          cd -
+      - name: pgp-packet-library
+        run: |
+          git clone https://github.com/summitto/pgp-packet-library.git
+          git -C pgp-packet-library submodule update --init --recursive
+          cmake -B pgp-packet-library/build -S pgp-packet-library -DCMAKE_C_COMPILER=clang-9 -DCMAKE_CXX_COMPILER=clang++-9 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=ci-install
+          cmake --build pgp-packet-library/build --target install
+      - name: cmake
+        run: cmake -B build -DCMAKE_C_COMPILER=clang-9 -DCMAKE_CXX_COMPILER=clang++-9 -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=ci-install
+      - name: build
+        run: cmake --build build
+      - name: test
+        run: make -C build test

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,31 @@
+name: "build and test"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  appleclang:
+    name: appleclang-11.0.3
+    runs-on: macos-latest
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: dependencies
+      run: brew install boost cryptopp
+    - name: pgp-packet-library
+      run: |
+        git clone https://github.com/summitto/pgp-packet-library.git
+        git -C pgp-packet-library submodule update --init --recursive
+        cmake -B pgp-packet-library/build -S pgp-packet-library -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=ci-install
+        cmake --build pgp-packet-library/build --target install
+    - name: cmake
+      run: cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_PREFIX_PATH=ci-install
+    - name: build
+      run: cmake --build build
+    - name: test
+      run: make -C build test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(generate_derived_key pgp-packet)
 target_link_libraries(generate_derived_key Boost::program_options)
 
 # Add CryptoPP
-target_link_libraries(generate_derived_key ${CRYPTOPP_LIBRARIES})
+target_link_libraries(generate_derived_key CryptoPP::CryptoPP)
 
 # I don't know whether this is the earliest version that supports concepts, but
 # at least 8.2.1 supports it.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,8 +8,6 @@ project(pgp-test
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
-set(Boost_NO_BOOST_CMAKE ON)
-set(Boost_DEBUG ON)
 
 find_package(pgp-packet REQUIRED)
 find_package(Boost      REQUIRED

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ project(pgp-test
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(Boost_NO_BOOST_CMAKE ON)
+set(Boost_DEBUG ON)
 
 find_package(pgp-packet REQUIRED)
 find_package(Boost      REQUIRED

--- a/README.md
+++ b/README.md
@@ -41,44 +41,43 @@ generate a key.
   https://github.com/summitto/raspbian_setup
 - install `GnuPG` on your main device. Optionally, `scdaemon`, `libccid` and
   `pcscd` may need to be installed.
+- raise the lockable memory limit to at least 1M in `/etc/security/limits.conf` and get a new session
 - run key generation utility, for example using:
-
-    generate_derived_key -o keyfile -t eddsa -n "firstname lastname" -e email
-    -s "2011-01-01 01:01:01" -x "2099-09-09 09:09:09" -k "12345678" -c "2011-01-01
-    01:01:01"
-
+```
+generate_derived_key -o keyfile -t eddsa -n "firstname lastname" -e email -s "2011-01-01 01:01:01" -x "2099-09-09 09:09:09" -k "12345678" -c "2011-01-01 01:01:01"
+```
 - The program will either generate a new encrypted seed using dice input, or you
   can use an existing encrypted seed to generate your key. If you generate a
   new seed, store it in a secure place.  
-- import the generated key file into gpg with "gpg --import file". 
+- import the generated key file into gpg with `gpg --import ${KEYFILE}`. 
 
 If you have a smart card, you can import the private key as follows:
-
 - insert the smart card (e.g. Yubikey or Nitrokey)
-- run gpg --key-edit keyid
-- toggle
-- key 1
-- keytocard
-- key 1
-- key 2
-- keytocard
-- key 2
-- key 3
-- keytocard
-- save
-- gpg --export publickeyfile
-- gpg --delete-secret-and-public-keys keyid
+- run `gpg --key-edit keyid` and provide the next input
+```
+toggle
+key 1
+keytocard
+key 1
+key 2
+keytocard
+key 2
+key 3
+keytocard
+save
+```
+- export your public key with `gpg --export ${KEYID} > ${KEYFILE}`
+- delete the keys from gpg with `gpg --delete-secret-and-public-keys ${KEYID}`
 - copy the public key file to a usb stick and import it on your target computer
 - insert the smart card in the target computer
-- run gpg --card-edit
-- fetch
+- run `gpg --card-edit` and `fetch`
 
 You should now have a functional key. You can test it as follows:
 
-- gpg --list-keys 
-- echo helloworld > test.txt
-- gpg -r [key id] --encrypt test.txt
-- gpg --decrypt test.txt.gpg
+- list all the keys with `gpg --list-keys` 
+- create a file to encrypt with `echo helloworld > test.txt`
+- encrypt the file with `gpg -r ${KEYID} --encrypt test.txt`
+- decrypt the file with `gpg --decrypt test.txt.gpg`
 
 ## Updating existing keys
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # !!! EXPERIMENTAL - use at your own risk !!!
 
+![pgp-key-generation CI](https://github.com/summitto/pgp-key-generation/workflows/pgp-key-generation%20CI/badge.svg)
+
 # PGP key generation
 
 This repository provides the source for a utility used for creating PGP keys using
@@ -21,6 +23,12 @@ The source code can be built using only the dependencies of the
 The integration testing script, which can be run using `make test` in
 the build folder, additionally requires Python 3.7 (or 3.6 with
 the `dataclasses` library) and GnuPG to be installed.
+
+| Compiler      | Minimum version |
+| :---          |     :---:       |
+| Apple clang   | 11.0.3          |
+| clang         | 9.0.0           |
+| gcc           | 8.0.0           |
 
 ## Generating new keys
 

--- a/cmake/Modules/FindCryptoPP.cmake
+++ b/cmake/Modules/FindCryptoPP.cmake
@@ -1,110 +1,25 @@
-# Originally from: https://gist.github.com/colejhudson/bd4f91efb453c50483152918e3337745
+find_path(CryptoPP_INCLUDE_DIR NAMES cryptopp/config.h DOC "CryptoPP include directory")
+find_library(CryptoPP_LIBRARY NAMES cryptopp DOC "CryptoPP library")
 
-# Module for locating the Crypto++ encryption library.
-#
-# Customizable variables:
-#   CRYPTOPP_ROOT_DIR
-#     This variable points to the CryptoPP root directory. On Windows the
-#     library location typically will have to be provided explicitly using the
-#     -D command-line option. The directory should include the include/cryptopp,
-#     lib and/or bin sub-directories.
-#
-# Read-only variables:
-#   CRYPTOPP_FOUND
-#     Indicates whether the library has been found.
-#
-#   CRYPTOPP_INCLUDE_DIRS
-#     Points to the CryptoPP include directory.
-#
-#   CRYPTOPP_LIBRARIES
-#     Points to the CryptoPP libraries that should be passed to
-#     target_link_libararies.
-#
-#
-# Copyright (c) 2012 Sergiu Dotenco
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
+if(CryptoPP_INCLUDE_DIR)
+    file(STRINGS ${CryptoPP_INCLUDE_DIR}/cryptopp/config.h _config_version REGEX "CRYPTOPP_VERSION")
+    string(REGEX MATCH "([0-9])([0-9])([0-9])" _match_version ${_config_version})
+    set(CryptoPP_VERSION_STRING "${CMAKE_MATCH_1}.${CMAKE_MATCH_2}.${CMAKE_MATCH_3}")
+endif()
 
-INCLUDE (FindPackageHandleStandardArgs)
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CryptoPP
+    REQUIRED_VARS CryptoPP_INCLUDE_DIR CryptoPP_LIBRARY
+    FOUND_VAR CryptoPP_FOUND
+    VERSION_VAR CryptoPP_VERSION_STRING)
 
-FIND_PATH (CRYPTOPP_ROOT_DIR
-  NAMES cryptopp/cryptlib.h include/cryptopp/cryptlib.h
-  PATHS ENV CRYPTOPPROOT
-  DOC "CryptoPP root directory")
+if(CryptoPP_FOUND AND NOT TARGET CryptoPP::CryptoPP)
+    add_library(CryptoPP::CryptoPP UNKNOWN IMPORTED)
+    set_target_properties(CryptoPP::CryptoPP PROPERTIES
+        IMPORTED_LOCATION "${CryptoPP_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${CryptoPP_INCLUDE_DIR}")
+endif()
 
-# Re-use the previous path:
-FIND_PATH (CRYPTOPP_INCLUDE_DIR
-  NAMES cryptopp/cryptlib.h
-  HINTS ${CRYPTOPP_ROOT_DIR}
-  PATH_SUFFIXES include
-  DOC "CryptoPP include directory")
-
-FIND_LIBRARY (CRYPTOPP_LIBRARY_DEBUG
-  NAMES cryptlibd cryptoppd
-  HINTS ${CRYPTOPP_ROOT_DIR}
-  PATH_SUFFIXES lib
-  DOC "CryptoPP debug library")
-
-FIND_LIBRARY (CRYPTOPP_LIBRARY_RELEASE
-  NAMES cryptlib cryptopp
-  HINTS ${CRYPTOPP_ROOT_DIR}
-  PATH_SUFFIXES lib
-  DOC "CryptoPP release library")
-
-IF (CRYPTOPP_LIBRARY_DEBUG AND CRYPTOPP_LIBRARY_RELEASE)
-  SET (CRYPTOPP_LIBRARY
-    optimized ${CRYPTOPP_LIBRARY_RELEASE}
-    debug ${CRYPTOPP_LIBRARY_DEBUG} CACHE DOC "CryptoPP library")
-ELSEIF (CRYPTOPP_LIBRARY_RELEASE)
-  SET (CRYPTOPP_LIBRARY ${CRYPTOPP_LIBRARY_RELEASE} CACHE STRING
-    "CryptoPP library")
-ENDIF (CRYPTOPP_LIBRARY_DEBUG AND CRYPTOPP_LIBRARY_RELEASE)
-
-IF (CRYPTOPP_INCLUDE_DIR)
-  SET (_CRYPTOPP_VERSION_HEADER ${CRYPTOPP_INCLUDE_DIR}/cryptopp/config.h)
-
-  IF (EXISTS ${_CRYPTOPP_VERSION_HEADER})
-    FILE (STRINGS ${_CRYPTOPP_VERSION_HEADER} _CRYPTOPP_VERSION_TMP REGEX
-      "^#define CRYPTOPP_VERSION[ \t]+[0-9]+$")
-
-    STRING (REGEX REPLACE
-      "^#define CRYPTOPP_VERSION[ \t]+([0-9]+)" "\\1" _CRYPTOPP_VERSION_TMP
-      ${_CRYPTOPP_VERSION_TMP})
-
-    STRING (REGEX REPLACE "([0-9]+)[0-9][0-9]" "\\1" CRYPTOPP_VERSION_MAJOR
-      ${_CRYPTOPP_VERSION_TMP})
-    STRING (REGEX REPLACE "[0-9]([0-9])[0-9]" "\\1" CRYPTOPP_VERSION_MINOR
-      ${_CRYPTOPP_VERSION_TMP})
-    STRING (REGEX REPLACE "[0-9][0-9]([0-9])" "\\1" CRYPTOPP_VERSION_PATCH
-      ${_CRYPTOPP_VERSION_TMP})
-
-    SET (CRYPTOPP_VERSION_COUNT 3)
-    SET (CRYPTOPP_VERSION
-      ${CRYPTOPP_VERSION_MAJOR}.${CRYPTOPP_VERSION_MINOR}.${CRYPTOPP_VERSION_PATCH})
-  ENDIF (EXISTS ${_CRYPTOPP_VERSION_HEADER})
-ENDIF (CRYPTOPP_INCLUDE_DIR)
-
-SET (CRYPTOPP_INCLUDE_DIRS ${CRYPTOPP_INCLUDE_DIR})
-SET (CRYPTOPP_LIBRARIES ${CRYPTOPP_LIBRARY})
-
-MARK_AS_ADVANCED (CRYPTOPP_INCLUDE_DIR CRYPTOPP_LIBRARY CRYPTOPP_LIBRARY_DEBUG
-  CRYPTOPP_LIBRARY_RELEASE)
-
-FIND_PACKAGE_HANDLE_STANDARD_ARGS (CryptoPP REQUIRED_VARS CRYPTOPP_ROOT_DIR
-  CRYPTOPP_INCLUDE_DIR CRYPTOPP_LIBRARY VERSION_VAR CRYPTOPP_VERSION)
+mark_as_advanced(CryptoPP_INCLUDE_DIR CryptoPP_LIBRARY)
+set(CryptoPP_INCLUDE_DIRS ${CryptoPP_INCLUDE_DIR})
+set(CryptoPP_LIBRARIES ${CryptoPP_LIBRARY})

--- a/mnemonics/language.h
+++ b/mnemonics/language.h
@@ -23,17 +23,17 @@ namespace mnemonics {
      *  The available langauges and their
      *  word lists.
      */
-    const static std::array<std::pair<std::string_view, const word_list_t&>, 9> languages{
-        std::make_pair("Chinese (simplified)",   chinese_simplified),
-        std::make_pair("Chinese (traditional)",  chinese_traditional),
-        std::make_pair("Czech",                  czech),
-        std::make_pair("English",                english),
-        std::make_pair("French",                 french),
-        std::make_pair("Italian",                italian),
-        std::make_pair("Japanese",               japanese),
-        std::make_pair("Korean",                 korean),
-        std::make_pair("Spanish",                spanish)
-    };
+    constexpr const std::array<std::pair<std::string_view, const word_list_t&>, 9> languages{{
+        {"Chinese (simplified)",   chinese_simplified},
+        {"Chinese (traditional)",  chinese_traditional},
+        {"Czech",                  czech},
+        {"English",                english},
+        {"French",                 french},
+        {"Italian",                italian},
+        {"Japanese",               japanese},
+        {"Korean",                 korean},
+        {"Spanish",                spanish}
+    }};
 
     /**
      *  Retrieve a description for the language

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -498,7 +498,7 @@ def run_test(exec_name, key_class):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("exec_name", help="generate_derived_key executable")
-    parser.add_argument("-n", "--num_tests", required=False, type=int, default=200,
+    parser.add_argument("-n", "--num_tests", required=False, type=int, default=5,
                         help="Number of repetitions to run for the tests.")
 
     args = parser.parse_args()

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -44,6 +44,7 @@ class AppInput:
     key_creation: str
 
     # Generate an input specification given a key type
+    @staticmethod
     def generate(key_type):
         values = generateInput()
         return AppInput(
@@ -131,7 +132,7 @@ class Application:
         return line
 
     def read_all(self):
-        lines = self._proc.stdout.read().decode("utf8").split("\n")
+        lines = self._proc.communicate()[0].decode("utf8").split("\n")
         if self._line_filter is None:
             return "\n".join(lines)
         else:
@@ -280,8 +281,8 @@ def generate_initial_key(workdir, exec_name, appinput):
         app.write_line("")  # generate a new key, no recovery seed
         app.write_line(appinput.dice)
         app.write_line("yes")
+        app.write_line("base36")
         app.write_line(appinput.key)
-
         text = app.read_all()
         idx1 = text.find("write down the following recovery seed:")
         idx2 = text.rfind("write down the following recovery seed:")


### PR DESCRIPTION
This PR enables github actions for the `clang` and `appleclang` compilers.

It also solves a static initialization order fiasco introduced in the mnemonic seed feature which was only present using `g++`

The readme was also updated and should be enough to resolve https://github.com/summitto/pgp-key-generation/issues/42