### PR TITLE
Hardcode key derication context to 'pgpkeyid'

### DIFF
--- a/src/extend_key_expiry/extend_key_expiry.cpp
+++ b/src/extend_key_expiry/extend_key_expiry.cpp
@@ -26,7 +26,7 @@ int main(int argc, const char **argv) {
 
         // create our simple user id packet
         key_expiry::public_key data{ *options.input_file };
-        auto packets = data.regenerate(master, *options.kdf_context, options.debug_dump_keys, *options.extension_period);
+        auto packets = data.regenerate(master, options.debug_dump_keys, *options.extension_period);
     
         // determine output size
         size_t data_size = std::accumulate(packets.begin(), packets.end(), 0, [](size_t a, auto &&b) -> size_t {

--- a/src/extend_key_expiry/options.cpp
+++ b/src/extend_key_expiry/options.cpp
@@ -22,7 +22,6 @@ namespace key_expiry {
             ("help,h",                                                                          "Produce help message")
             ("input-file,i",  po::value<util::opt_prompt<std::string>>(&input_file),            "Public key file")
             ("output-file,o",  po::value<util::opt_prompt<std::string>>(&output_file),          "Output file")
-            ("kdf-context,k",  po::value<util::opt_prompt<std::string>>(&kdf_context),          "Key derivation context (8 bytes)")
             ("extension-period,e",  po::value<util::opt_prompt<uint32_t>>(&extension_period),   "Key expiry extension period in days")
             ("debug-dump-secret-and-public-keys", po::bool_switch(&debug_dump_keys),            "Dump generated key parameters; WARNING: sensitive data!");
 
@@ -59,12 +58,7 @@ namespace key_expiry {
         // ensure that all the options are initialized by possibly reading some from standard input
         input_file.ensure_prompt("Public key file");
         output_file.ensure_prompt("Output file");
-        kdf_context.ensure_prompt("Key derivation context (8 bytes)");
         extension_period.ensure_prompt("Key expiry extension period in days");
 
-        // check that the KDF context is the right size
-        if (kdf_context->size() != 8) {
-            throw std::invalid_argument{ "Invalid key derivation context size, expected 8 bytes." };
-        }
     }
 }

--- a/src/extend_key_expiry/options.h
+++ b/src/extend_key_expiry/options.h
@@ -19,9 +19,6 @@ namespace key_expiry {
         // the key output file
         util::opt_prompt<std::string> output_file;
 
-        // meta-information for the key derivation
-        util::opt_prompt<std::string> kdf_context;
-
         // the key expiry extension period
         util::opt_prompt<uint32_t>    extension_period;
 

--- a/src/extend_key_expiry/public_key.cpp
+++ b/src/extend_key_expiry/public_key.cpp
@@ -124,21 +124,20 @@ namespace key_expiry {
      *  Regenerates the secret key packet
      *
      *  @param  master              The master key used to generate the packet
-     *  @param  kdf_context         The context used to generate the packet
      *  @param  debug_dump_keys     Whether the keys should be printed or not for debugging purposes
      *  @param  extension_period    The expiry extension period in days
      */
-    std::vector<pgp::packet> public_key::regenerate(const master_key& master, boost::string_view kdf_context, bool debug_dump_keys, uint32_t extension_period) const {
+    std::vector<pgp::packet> public_key::regenerate(const master_key& master, bool debug_dump_keys, uint32_t extension_period) const {
         uint32_t expiration = expiration_timestamp() + epoch_day_time * extension_period;
         std::vector<pgp::packet> retval;
 
         switch (algorithm()) {
             case pgp::key_algorithm::eddsa: {
-                retval = generate_key<parameters::eddsa>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, kdf_context, debug_dump_keys);
+                retval = generate_key<parameters::eddsa>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, debug_dump_keys);
                 break;
             }
             case pgp::key_algorithm::ecdsa: {
-                retval = generate_key<parameters::ecdsa>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, kdf_context, debug_dump_keys);
+                retval = generate_key<parameters::ecdsa>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, debug_dump_keys);
                 break;
             }
             case pgp::key_algorithm::rsa_encrypt_or_sign: {
@@ -151,13 +150,13 @@ namespace key_expiry {
                 // generate the right key
                 switch (rsa_bit_size) {
                     case 2048:
-                        retval = generate_key<parameters::rsa<2048>>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, kdf_context, debug_dump_keys);
+                        retval = generate_key<parameters::rsa<2048>>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, debug_dump_keys);
                         break;
                     case 4096:
-                        retval = generate_key<parameters::rsa<4096>>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, kdf_context, debug_dump_keys);
+                        retval = generate_key<parameters::rsa<4096>>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, debug_dump_keys);
                         break;
                     case 8192:
-                        retval = generate_key<parameters::rsa<8192>>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, kdf_context, debug_dump_keys);
+                        retval = generate_key<parameters::rsa<8192>>(master, user_id(), creation_timestamp(), signature_creation_timestamp(), expiration, debug_dump_keys);
                         break;
                     default:
                         throw std::invalid_argument{ "Invalid RSA modulus size" };

--- a/src/extend_key_expiry/public_key.h
+++ b/src/extend_key_expiry/public_key.h
@@ -81,11 +81,10 @@ namespace key_expiry {
          *  Regenerates the secret key packet
          *
          *  @param  master              The master key used to generate the packet
-         *  @param  kdf_context         The context used to generate the packet
          *  @param  debug_dump_keys     Whether the keys should be printed or not for debugging purposes
          *  @param  extension_period    The expiry extension period in days
          */
-        std::vector<pgp::packet> regenerate(const master_key& master, boost::string_view kdf_context, bool debug_dump_keys, uint32_t extension_period) const;
+        std::vector<pgp::packet> regenerate(const master_key& master, bool debug_dump_keys, uint32_t extension_period) const;
 
         /**
          *  Retrieves a string with the information of the key for debugging

--- a/src/generate_derived_key/generate_derived_key.cpp
+++ b/src/generate_derived_key/generate_derived_key.cpp
@@ -101,7 +101,7 @@ int main(int argc, const char **argv)
         std::time_t signature_expiration_timestamp  = time_utils::tm_to_utc_unix_timestamp(*options.signature_expiration);
 
         // select the function with which to generate the packets
-        std::function<std::vector<pgp::packet>(const master_key&, std::string, uint32_t, uint32_t, uint32_t, boost::string_view, bool)> generation_function;
+        std::function<std::vector<pgp::packet>(const master_key&, std::string, uint32_t, uint32_t, uint32_t, bool)> generation_function;
         switch (*options.type) {
             case util::key_class::eddsa: generation_function = generate_key<parameters::eddsa>; break;
             case util::key_class::ecdsa: generation_function = generate_key<parameters::ecdsa>; break;
@@ -111,7 +111,7 @@ int main(int argc, const char **argv)
         }
 
         // generate the packets
-        auto packets = generation_function(master, std::move(user_id), key_creation_timestamp, signature_creation_timestamp, signature_expiration_timestamp, *options.kdf_context, options.debug_dump_keys);
+        auto packets = generation_function(master, std::move(user_id), key_creation_timestamp, signature_creation_timestamp, signature_expiration_timestamp, options.debug_dump_keys);
 
         // determine output size
         size_t data_size = std::accumulate(packets.begin(), packets.end(), 0, [](size_t a, auto &&b) -> size_t {

--- a/src/generate_derived_key/options.cpp
+++ b/src/generate_derived_key/options.cpp
@@ -26,7 +26,6 @@ namespace key_generation {
             ("email,e",        po::value<util::opt_prompt<std::string>>(&user_email),                   "Your email address")
             ("sigtime,s",      po::value<util::opt_prompt<util::tm_wrapper>> (&signature_creation),     "Signature creation time in UTC (YYYY-MM-DD HH:MM:SS)")
             ("sigexpiry,x",    po::value<util::opt_prompt<util::tm_wrapper>> (&signature_expiration),   "Signature expiration time in UTC (YYYY-MM-DD HH:MM:SS)")
-            ("kdf-context,k",  po::value<util::opt_prompt<std::string>>(&kdf_context),                  "Key derivation context (8 bytes)")
             ("key-creation,c", po::value<util::opt_prompt<util::tm_wrapper>> (&key_creation),           "Key creation time in UTC (YYYY-MM-DD HH:MM:SS)")
             ("debug-dump-secret-and-public-keys", po::bool_switch(&debug_dump_keys),                    "Dump generated key parameters; WARNING: sensitive data!");
 
@@ -67,13 +66,7 @@ namespace key_generation {
         user_email          .ensure_prompt("Your email address");
         signature_creation  .ensure_prompt("Signature creation time in UTC (YYYY-MM-DD HH:MM:SS)");
         signature_expiration.ensure_prompt("Signature expiration time in UTC (YYYY-MM-DD HH:MM:SS)");
-        kdf_context         .ensure_prompt("Key derivation context (8 bytes)");
         key_creation        .ensure_prompt("Key creation time in UTC (YYYY-MM-DD HH:MM:SS)");
 
-        // check that the KDF context is the right size
-        if (kdf_context->size() != 8) {
-            // alert the user to the invalid input and exit
-            throw std::invalid_argument{ "Invalid key derivation context size, expected 8 bytes." };
-        }
     }
 }

--- a/src/shared/derived_key.h
+++ b/src/shared/derived_key.h
@@ -13,18 +13,21 @@ template <size_t size>
 class derived_key : public pgp::secure_object<std::array<uint8_t, size>>
 {
     public:
+        
+        // use a fixed key derivation context for the derivation of keys.
+        // Its purpose is to mitigate accidental bugs by separating
+        // domains. 
+        constexpr const static boost::string_view context{ "pgpkeyid" };
+
         /**
          *  Constructor
          *
          *  @param  master  The master key to derive from
          *  @param  index   The derivation index
-         *  @param  context The context to derive in
          */
-        derived_key(const master_key &master, uint64_t index, boost::string_view context)
+        derived_key(const master_key &master, uint64_t index)
         {
-            if (context.size() != 8) {
-                throw std::logic_error("Derivation context in a derived_key must have length 8");
-            }
+            static_assert(context.size() == 8, "Derivation context in a derived_key must have length 8");
 
             // derive the subkey
             crypto_kdf_derive_from_key(this->data(), size, index, context.data(), master.data());

--- a/src/shared/generate_key.h
+++ b/src/shared/generate_key.h
@@ -96,20 +96,19 @@ concept bool KeyParameters() {
  *  @param  creation    The creation timestamp for the key
  *  @param  signature   The creation timestamp for the signature
  *  @param  expiration  The expiration timestamp for the signature
- *  @param  context     The context to use for deriving the keys
  */
 template <KeyParameters params_t>
-std::vector<pgp::packet> generate_key(const master_key &master, std::string user, uint32_t creation, uint32_t signature, uint32_t expiration, boost::string_view context, bool debug_dump_keys)
+std::vector<pgp::packet> generate_key(const master_key &master, std::string user, uint32_t creation, uint32_t signature, uint32_t expiration, bool debug_dump_keys)
 {
     // pgp likes the expiration timestamp to not be a timestamp (but still call it that)
     // but instead define it as the number of seconds since the key creation timestamp
     expiration -= creation;
 
     // derive the keys from the master
-    derived_key<params_t::derivation_size> main_key_derivation             { master, 1, context };
-    derived_key<params_t::derivation_size> signing_key_derivation          { master, 2, context };
-    derived_key<params_t::derivation_size> encryption_key_derivation       { master, 3, context };
-    derived_key<params_t::derivation_size> authentication_key_derivation   { master, 4, context };
+    derived_key<params_t::derivation_size> main_key_derivation             { master, 1 };
+    derived_key<params_t::derivation_size> signing_key_derivation          { master, 2 };
+    derived_key<params_t::derivation_size> encryption_key_derivation       { master, 3 };
+    derived_key<params_t::derivation_size> authentication_key_derivation   { master, 4 };
 
     // Compute the keys from the derivation data.
     const auto keys{

--- a/tests/generate.py
+++ b/tests/generate.py
@@ -48,7 +48,6 @@ def generateInput():
         "expiration": date_expiration,
         "dice": generateDice(),
         "key": generateSymmetricKey(),
-        "context": generateString(minstrlen=8, maxstrlen=8),
         "key_creation": date_key_creation,
         "extension_period": str(date_extension),
     }

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -39,7 +39,6 @@ class AppInput:
     expiration: str
     dice: str
     key: str
-    context: str
     key_creation: str
     extension_period: str
 
@@ -55,7 +54,6 @@ class AppInput:
             values["expiration"],
             values["dice"],
             values["key"],
-            values["context"],
             values["key_creation"],
             values["extension_period"],
         )
@@ -151,7 +149,6 @@ class KeygenApplication(Application):
             "-e", appinput.email,
             "-s", appinput.creation,
             "-x", appinput.expiration,
-            "-k", appinput.context,
             "-c", appinput.key_creation
         ]
 
@@ -165,7 +162,6 @@ class ExtendExpiryApplication(Application):
         args = [
             "-i", input_file,
             "-o", output_file,
-            "-k", appinput.context,
             "-e", appinput.extension_period
         ]
 
@@ -460,7 +456,7 @@ def report_error(appinput, keyfile, rec_seed):
     print("Command line: -t {} -n {} -e {} -s {} -x {} -k {} -c {}".format(
         *(shlex.quote(x) for x in
             [appinput.key_type, appinput.name, appinput.email, appinput.creation,
-            appinput.expiration, appinput.context, appinput.key_creation])
+            appinput.expiration, appinput.key_creation])
     ))
     print("Dice: {}".format(appinput.dice))
     print("Encryption key: {}".format(appinput.key))


### PR DESCRIPTION
This improves usability somewhat. For recovery, it is important that the user remembers the derivation context or has access to this repository (in which it is hardcoded), which will be explained in the README.